### PR TITLE
Removed extra comma from messenger.ses

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -22,6 +22,6 @@ config = '''
 {
     "access_key": "",
     "secret_key": "",
-    "region": "",
+    "region": ""
 }
 '''


### PR DESCRIPTION
The comma breaks the configuration.