### PR TITLE
Allow for role based credentials

### DIFF
--- a/messenger/pinpoint.go
+++ b/messenger/pinpoint.go
@@ -94,22 +94,22 @@ func NewPinpoint(cfg []byte, l *onelog.Logger) (Messenger, error) {
 	if c.AppID == "" {
 		return nil, fmt.Errorf("invalid app_id")
 	}
-	if c.Region == "" {
-		return nil, fmt.Errorf("invalid region")
+
+	config := &aws.Config{
+		MaxRetries: aws.Int(3),
 	}
-	if c.AccessKey == "" {
-		return nil, fmt.Errorf("invalid access_key")
+	if c.AccessKey != "" && c.SecretKey != "" {
+		config.Credentials = credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, "")
 	}
-	if c.SecretKey == "" {
-		return nil, fmt.Errorf("invalid secret_key")
+	if c.Region != "" {
+		config.Region = &c.Region
 	}
 
-	sess := session.Must(session.NewSession())
-	svc := pinpoint.New(sess,
-		aws.NewConfig().
-			WithCredentials(credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, "")).
-			WithRegion(c.Region),
-	)
+	var sess = session.Must(session.NewSession(config))
+	if !checkCredentials(sess) {
+		return nil, fmt.Errorf("invalid credentials")
+	}
+	svc := pinpoint.New(sess)
 
 	return pinpointMessenger{
 		client: svc,

--- a/messenger/pinpoint.go
+++ b/messenger/pinpoint.go
@@ -106,8 +106,9 @@ func NewPinpoint(cfg []byte, l *onelog.Logger) (Messenger, error) {
 	}
 
 	var sess = session.Must(session.NewSession(config))
-	if !checkCredentials(sess) {
-		return nil, fmt.Errorf("invalid credentials")
+	err := checkCredentials(sess)
+	if err != nil {
+		return nil, err
 	}
 	svc := pinpoint.New(sess)
 

--- a/messenger/ses.go
+++ b/messenger/ses.go
@@ -102,13 +102,13 @@ func (s sesMessenger) Close() error {
 	return nil
 }
 
-func checkCredentials(sess *session.Session) bool {
+func checkCredentials(sess *session.Session) error {
 	// Create a SES service client.
 	svc := sts.New(sess)
 	// Call the GetCallerIdentity API to check credentials
 	params := &sts.GetCallerIdentityInput{}
 	_, err := svc.GetCallerIdentity(params)
-	return err != nil
+	return err
 }
 
 // NewAWSSES creates new instance of pinpoint
@@ -129,8 +129,9 @@ func NewAWSSES(cfg []byte, l *onelog.Logger) (Messenger, error) {
 	}
 
 	var sess = session.Must(session.NewSession(config))
-	if !checkCredentials(sess) {
-		return nil, fmt.Errorf("invalid credentials")
+	err := checkCredentials(sess)
+	if err != nil {
+		return nil, err
 	}
 
 	svc := ses.New(sess)


### PR DESCRIPTION
Awesome project! I want to implement this without having to have long live credentials, so I put together this PR. Feel free to take it, close it, or modify.

When running inside of a container, credentials can be provided through environment variables, role assumption, etc. The current code was simply checking for the presence of a value. This PR changes to accepting the config and verifying the role through checkCredentials `sts GetCallerIdentity`. It also allows you to use the other authentication methods, such as env.